### PR TITLE
feat: install bun using official installer

### DIFF
--- a/laptop
+++ b/laptop
@@ -164,6 +164,9 @@ asdf reshim elixir
 fancy_echo "Installing latest Node.js..."
 install_asdf_language "nodejs"
 
+fancy_echo "Installing latest Bun..."
+curl -fsSL https://bun.sh/install | bash
+
 # Install npm global packages
 
  npm install -g agent-browser # agent-browser, headless browser automation CLI for AI agents


### PR DESCRIPTION
## Summary
- Add Bun runtime installation to the laptop setup script
- Uses the official install script from bun.sh (`curl -fsSL https://bun.sh/install | bash`)
- Placed after Node.js installation, before npm global packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)